### PR TITLE
Use Gradle Application Plugin for distribution

### DIFF
--- a/buildSrc/src/main/groovy/tsubakuro-examples.app-conventions.gradle
+++ b/buildSrc/src/main/groovy/tsubakuro-examples.app-conventions.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'tsubakuro-examples.java-conventions'
+    id 'application'
 }
 
 configurations {

--- a/modules/clients/build.gradle
+++ b/modules/clients/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     implementation 'commons-cli:commons-cli:1.4'
 }
 
-tasks.register('run', JavaExec) {
+tasks.register('runExample', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'com.tsurugidb.tsubakuro.examples.Main'
 

--- a/modules/tpcc/build.gradle
+++ b/modules/tpcc/build.gradle
@@ -16,3 +16,16 @@ tasks.register('runTpcc', JavaExec) {
 
     dependsOn copyNativeLib
 }
+
+startScripts {
+    applicationName = 'tpcc'
+    mainClass = 'com.tsurugidb.tsubakuro.examples.tpcc.Main'
+    applicationDefaultJvmArgs = [
+        '-Dcom.tsurugidb.tsubakuro.jniverify=false',
+        '-Dtsurugi.dbname=ipc:tateyama'
+    ]
+}
+
+distTar {
+    archiveName = "${project.name}.tar"
+}


### PR DESCRIPTION
ベンチマークアプリケーションのリリース方法をGradle Application Pluginを使う方法に統一するための build.gradle の修正です。

`modules/clients/build.gradle` に `run` という名前のタスクが定義されていましたが、本修正とタスク名がバッティングするため既存の `run` タスクは `runExample` というタスク名に変更しました。