### PR TITLE
Change distTar.archiveFileName to tar.gz

### DIFF
--- a/modules/tpcc/build.gradle
+++ b/modules/tpcc/build.gradle
@@ -27,5 +27,7 @@ startScripts {
 }
 
 distTar {
-    archiveFileName = "${project.name}.tar"
+    archiveFileName = "${project.name}.tar.gz"
+    archiveExtension = 'tar.gz'
+    compression = Compression.GZIP
 }


### PR DESCRIPTION
Gradleの distTar タスクで生成されるtarballを .tar から .tar.gz に変更します。