### PR TITLE
Remove to use tsubakuro-jni

### DIFF
--- a/buildSrc/src/main/groovy/tsubakuro-examples.app-conventions.gradle
+++ b/buildSrc/src/main/groovy/tsubakuro-examples.app-conventions.gradle
@@ -3,22 +3,10 @@ plugins {
     id 'application'
 }
 
-configurations {
-    nativeLib
-}
-
 dependencies {
     implementation "com.tsurugidb.tsubakuro:tsubakuro-session:${tsubakuroVersion}"
     implementation "com.tsurugidb.tsubakuro:tsubakuro-connector:${tsubakuroVersion}"
     implementation "com.tsurugidb.tsubakuro:tsubakuro-explain:${tsubakuroVersion}"
 
     implementation 'org.slf4j:slf4j-simple:1.7.32'
-
-    nativeLib "com.tsurugidb.tsubakuro:tsubakuro-jni:${tsubakuroVersion}"
-}
-
-task copyNativeLib(type: Copy) {
-    from  configurations.nativeLib
-    into "${buildDir}/native"
-    rename "tsubakuro-jni-${tsubakuroVersion}.so", 'libtsubakuro.so'
 }

--- a/modules/cases/build.gradle
+++ b/modules/cases/build.gradle
@@ -10,43 +10,34 @@ tasks.register('runDateTime', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'com.tsurugidb.tsubakuro.examples.datetime.Main'
 
-    systemProperty 'com.tsurugidb.tsubakuro.jnilib', "${buildDir}/native/libtsubakuro.so"
     systemProperty 'tsurugi.dbname', findProperty('tsurugi.dbname') ?: 'ipc:tsurugi'
 
     systemProperty 'org.slf4j.simpleLogger.defaultLogLevel', findProperty('loglevel') ?: 'info'
     systemProperty 'org.slf4j.simpleLogger.showThreadName', 'false'
     systemProperty 'org.slf4j.simpleLogger.showShortLogName', 'true'
     systemProperty 'org.slf4j.simpleLogger.levelInBrackets', 'true'
-
-    dependsOn copyNativeLib
 }
 
 tasks.register('runIssue', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'com.tsurugidb.tsubakuro.examples.Main'
 
-    systemProperty 'com.tsurugidb.tsubakuro.jnilib', "${buildDir}/native/libtsubakuro.so"
     systemProperty 'tsurugi.dbname', findProperty('tsurugi.dbname') ?: 'ipc:tsurugi'
 
     systemProperty 'org.slf4j.simpleLogger.defaultLogLevel', findProperty('loglevel') ?: 'info'
     systemProperty 'org.slf4j.simpleLogger.showThreadName', 'false'
     systemProperty 'org.slf4j.simpleLogger.showShortLogName', 'true'
     systemProperty 'org.slf4j.simpleLogger.levelInBrackets', 'true'
-
-    dependsOn copyNativeLib
 }
 
 tasks.register('runMS', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'com.tsurugidb.tsubakuro.examples.multipleSelect.Main'
 
-    systemProperty 'com.tsurugidb.tsubakuro.jnilib', "${buildDir}/native/libtsubakuro.so"
     systemProperty 'tsurugi.dbname', findProperty('tsurugi.dbname') ?: 'ipc:tsurugi'
 
     systemProperty 'org.slf4j.simpleLogger.defaultLogLevel', findProperty('loglevel') ?: 'info'
     systemProperty 'org.slf4j.simpleLogger.showThreadName', 'false'
     systemProperty 'org.slf4j.simpleLogger.showShortLogName', 'true'
     systemProperty 'org.slf4j.simpleLogger.levelInBrackets', 'true'
-
-    dependsOn copyNativeLib
 }

--- a/modules/clients/build.gradle
+++ b/modules/clients/build.gradle
@@ -10,15 +10,12 @@ tasks.register('runExample', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'com.tsurugidb.tsubakuro.examples.Main'
 
-    systemProperty 'com.tsurugidb.tsubakuro.jnilib', "${buildDir}/native/libtsubakuro.so"
     systemProperty 'tsurugi.dbname', findProperty('tsurugi.dbname') ?: 'ipc:tsurugi'
 
     systemProperty 'org.slf4j.simpleLogger.defaultLogLevel', findProperty('loglevel') ?: 'info'
     systemProperty 'org.slf4j.simpleLogger.showThreadName', 'false'
     systemProperty 'org.slf4j.simpleLogger.showShortLogName', 'true'
     systemProperty 'org.slf4j.simpleLogger.levelInBrackets', 'true'
-
-    dependsOn copyNativeLib
 
     jvmArgs '-Dcom.sun.management.jmxremote.port=9999'
     jvmArgs '-Dcom.sun.management.jmxremote.authenticate=false'
@@ -29,22 +26,18 @@ tasks.register('runDataStore', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'com.tsurugidb.tsubakuro.examples.datastore.Main'
 
-    systemProperty 'com.tsurugidb.tsubakuro.jnilib', "${buildDir}/native/libtsubakuro.so"
     systemProperty 'tsurugi.dbname', findProperty('tsurugi.dbname') ?: 'ipc:tsurugi'
 
     systemProperty 'org.slf4j.simpleLogger.defaultLogLevel', findProperty('loglevel') ?: 'info'
     systemProperty 'org.slf4j.simpleLogger.showThreadName', 'false'
     systemProperty 'org.slf4j.simpleLogger.showShortLogName', 'true'
     systemProperty 'org.slf4j.simpleLogger.levelInBrackets', 'true'
-
-    dependsOn copyNativeLib
 }
 
 tasks.register('runDiagnostic', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'com.tsurugidb.tsubakuro.examples.diagnostics.JMXClient'
 
-    systemProperty 'com.tsurugidb.tsubakuro.jnilib', "${buildDir}/native/libtsubakuro.so"
     systemProperty 'tsurugi.dbname', findProperty('tsurugi.dbname') ?: 'ipc:tsurugi'
 
     systemProperty 'org.slf4j.simpleLogger.defaultLogLevel', findProperty('loglevel') ?: 'info'
@@ -57,13 +50,10 @@ tasks.register('runBook', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'com.tsurugidb.tsubakuro.examples.book.Main'
 
-    systemProperty 'com.tsurugidb.tsubakuro.jnilib', "${buildDir}/native/libtsubakuro.so"
     systemProperty 'tsurugi.dbname', findProperty('tsurugi.dbname') ?: 'ipc:tsurugi'
 
     systemProperty 'org.slf4j.simpleLogger.defaultLogLevel', findProperty('loglevel') ?: 'info'
     systemProperty 'org.slf4j.simpleLogger.showThreadName', 'false'
     systemProperty 'org.slf4j.simpleLogger.showShortLogName', 'true'
     systemProperty 'org.slf4j.simpleLogger.levelInBrackets', 'true'
-
-    dependsOn copyNativeLib
 }

--- a/modules/tpcc/build.gradle
+++ b/modules/tpcc/build.gradle
@@ -6,7 +6,6 @@ tasks.register('runTpcc', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'com.tsurugidb.tsubakuro.examples.tpcc.Main'
 
-    systemProperty 'com.tsurugidb.tsubakuro.jnilib', "${buildDir}/native/libtsubakuro.so"
     systemProperty 'com.tsurugidb.tsubakuro.jniverify', 'false'
     systemProperty 'tsurugi.dbname', findProperty('tsurugi.dbname') ?: 'ipc:tsurugi'
 
@@ -14,8 +13,6 @@ tasks.register('runTpcc', JavaExec) {
     systemProperty 'org.slf4j.simpleLogger.showThreadName', 'false'
     systemProperty 'org.slf4j.simpleLogger.showShortLogName', 'true'
     systemProperty 'org.slf4j.simpleLogger.levelInBrackets', 'true'
-
-    dependsOn copyNativeLib
 }
 
 startScripts {

--- a/modules/tpccLoader/build.gradle
+++ b/modules/tpccLoader/build.gradle
@@ -14,7 +14,6 @@ tasks.register('runTpccLoader', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'com.tsurugidb.tsubakuro.examples.tpccLoader.Main'
 
-    systemProperty 'com.tsurugidb.tsubakuro.jnilib', "${buildDir}/native/libtsubakuro.so"
     systemProperty 'com.tsurugidb.tsubakuro.jniverify', 'false'
     systemProperty 'tsurugi.dbname', findProperty('tsurugi.dbname') ?: 'ipc:tsurugi'
 
@@ -22,8 +21,6 @@ tasks.register('runTpccLoader', JavaExec) {
     systemProperty 'org.slf4j.simpleLogger.showThreadName', 'false'
     systemProperty 'org.slf4j.simpleLogger.showShortLogName', 'true'
     systemProperty 'org.slf4j.simpleLogger.levelInBrackets', 'true'
-
-    dependsOn copyNativeLib
 }
 
 startScripts {

--- a/modules/tpch/build.gradle
+++ b/modules/tpch/build.gradle
@@ -10,13 +10,10 @@ tasks.register('runTpch', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'com.tsurugidb.tsubakuro.examples.tpch.Main'
 
-    systemProperty 'com.tsurugidb.tsubakuro.jnilib', "${buildDir}/native/libtsubakuro.so"
     systemProperty 'tsurugi.dbname', findProperty('tsurugi.dbname') ?: 'ipc:tsurugi'
 
     systemProperty 'org.slf4j.simpleLogger.defaultLogLevel', findProperty('loglevel') ?: 'info'
     systemProperty 'org.slf4j.simpleLogger.showThreadName', 'false'
     systemProperty 'org.slf4j.simpleLogger.showShortLogName', 'true'
     systemProperty 'org.slf4j.simpleLogger.levelInBrackets', 'true'
-
-    dependsOn copyNativeLib
 }


### PR DESCRIPTION
https://github.com/project-tsurugi/tsubakuro/pull/310 に従い libtsubakuro.soはMavenリモートリポジトリから取得せずサーバ側に配置したものを使うようにします。

tsubakuro-examples の各 `runXXX` 系タスクは以下のドキュメントに従い利用者側がネイティブライブラリの解決を行うよう環境設定が必要となることに注意してください。
https://github.com/project-tsurugi/tsubakuro/blob/master/docs/native-library-ja.md