### PR TITLE
Kvs inttest with beforeall

### DIFF
--- a/modules/kvs/build.gradle
+++ b/modules/kvs/build.gradle
@@ -26,7 +26,7 @@ sourceSets {
     }
 }
 
-spotbugsKvsIntegrationTest.enabled = true
+spotbugsKvsIntegrationTest.enabled = false
 
 configurations {
     kvsIntegrationTestImplementation.extendsFrom testImplementation

--- a/modules/kvs/build.gradle
+++ b/modules/kvs/build.gradle
@@ -26,7 +26,7 @@ sourceSets {
     }
 }
 
-spotbugsKvsIntegrationTest.enabled = false
+spotbugsKvsIntegrationTest.enabled = true
 
 configurations {
     kvsIntegrationTestImplementation.extendsFrom testImplementation

--- a/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/basic/BasicPutGetRemoveTest.java
+++ b/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/basic/BasicPutGetRemoveTest.java
@@ -2,6 +2,7 @@ package com.tsurugidb.tsubakuro.kvs.basic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import com.tsurugidb.tsubakuro.kvs.KvsClient;
@@ -9,17 +10,18 @@ import com.tsurugidb.tsubakuro.kvs.PutType;
 import com.tsurugidb.tsubakuro.kvs.Record;
 import com.tsurugidb.tsubakuro.kvs.RecordBuffer;
 import com.tsurugidb.tsubakuro.kvs.RemoveType;
-import com.tsurugidb.tsubakuro.kvs.util.TestBase;
+import com.tsurugidb.tsubakuro.kvs.util.Utils;
 
-class BasicPutGetRemoveTest extends TestBase {
+class BasicPutGetRemoveTest {
 
     private static final String TABLE_NAME = "table" + BasicPutGetRemoveTest.class.getSimpleName();
     private static final String KEY_NAME = "k1";
     private static final String VALUE_NAME = "v1";
 
-    BasicPutGetRemoveTest() throws Exception {
+    @BeforeAll
+    static void setup() throws Exception {
         String schema = String.format("%s BIGINT PRIMARY KEY, %s BIGINT", KEY_NAME, VALUE_NAME);
-        createTable(TABLE_NAME, schema);
+        Utils.createTable(TABLE_NAME, schema);
     }
 
     private static void checkRecord(Record record, long key1, long value1) throws Exception {
@@ -37,7 +39,7 @@ class BasicPutGetRemoveTest extends TestBase {
     public void basicPutGetRemove() throws Exception {
         final long key1 = 1L;
         final long value1 = 100L;
-        try (var session = getNewSession(); var kvs = KvsClient.attach(session)) {
+        try (var session = Utils.getNewSession(); var kvs = KvsClient.attach(session)) {
             try (var tx = kvs.beginTransaction().await()) {
                 RecordBuffer buffer = new RecordBuffer();
                 buffer.add(KEY_NAME, key1);
@@ -77,7 +79,7 @@ class BasicPutGetRemoveTest extends TestBase {
         final long value2 = 201L;
         final long value3 = 202L;
         RecordBuffer buffer = new RecordBuffer();
-        try (var session = getNewSession(); var kvs = KvsClient.attach(session)) {
+        try (var session = Utils.getNewSession(); var kvs = KvsClient.attach(session)) {
             // {}; add initial (key1, value1)
             try (var tx = kvs.beginTransaction().await()) {
                 buffer.add(KEY_NAME, key1);
@@ -223,7 +225,7 @@ class BasicPutGetRemoveTest extends TestBase {
         final long key2 = 3L;
         final long value = 100L;
         RecordBuffer buffer = new RecordBuffer();
-        try (var session = getNewSession(); var kvs = KvsClient.attach(session)) {
+        try (var session = Utils.getNewSession(); var kvs = KvsClient.attach(session)) {
             try (var tx = kvs.beginTransaction().await()) {
                 buffer.add(KEY_NAME, key1);
                 buffer.add(VALUE_NAME, value);

--- a/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/basic/BatchTest.java
+++ b/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/basic/BatchTest.java
@@ -6,14 +6,14 @@ import org.junit.jupiter.api.Test;
 
 import com.tsurugidb.tsubakuro.kvs.BatchScript;
 import com.tsurugidb.tsubakuro.kvs.KvsClient;
-import com.tsurugidb.tsubakuro.kvs.util.TestBase;
+import com.tsurugidb.tsubakuro.kvs.util.Utils;
 
-class BatchTest extends TestBase {
+class BatchTest {
 
     @Test
     public void notSupportedYet() throws Exception {
         BatchScript script = new BatchScript();
-        try (var session = getNewSession(); var kvs = KvsClient.attach(session)) {
+        try (var session = Utils.getNewSession(); var kvs = KvsClient.attach(session)) {
             try (var tx = kvs.beginTransaction().await()) {
                 assertThrows(UnsupportedOperationException.class, () -> kvs.batch(tx, script).await());
                 kvs.rollback(tx).await();

--- a/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/basic/BeginTest.java
+++ b/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/basic/BeginTest.java
@@ -10,13 +10,13 @@ import com.tsurugidb.tsubakuro.kvs.KvsClient;
 import com.tsurugidb.tsubakuro.kvs.KvsServiceCode;
 import com.tsurugidb.tsubakuro.kvs.KvsServiceException;
 import com.tsurugidb.tsubakuro.kvs.TransactionOption;
-import com.tsurugidb.tsubakuro.kvs.util.TestBase;
+import com.tsurugidb.tsubakuro.kvs.util.Utils;
 
-class BeginTest extends TestBase {
+class BeginTest {
 
     @Test
     public void occ() throws Exception {
-        try (var session = getNewSession(); var kvs = KvsClient.attach(session)) {
+        try (var session = Utils.getNewSession(); var kvs = KvsClient.attach(session)) {
             try (var tx = kvs.beginTransaction().await()) {
                 kvs.rollback(tx);
             }
@@ -31,14 +31,14 @@ class BeginTest extends TestBase {
 
     @Test
     public void occWithArgs() throws Exception {
-        try (var session = getNewSession(); var kvs = KvsClient.attach(session)) {
+        try (var session = Utils.getNewSession(); var kvs = KvsClient.attach(session)) {
             {
                 var opt = TransactionOption.forShortTransaction().withLabel("abc").build();
                 KvsServiceException ex = assertThrows(KvsServiceException.class, () -> {
                     kvs.beginTransaction(opt).await();
                 });
                 assertEquals(KvsServiceCode.NOT_IMPLEMENTED, ex.getDiagnosticCode());
-                System.err.println(getLineNumber() + "\t" + ex.getMessage());
+                System.err.println(Utils.getLineNumber() + "\t" + ex.getMessage());
             }
             {
                 for (var p : Priority.values()) {
@@ -50,7 +50,7 @@ class BeginTest extends TestBase {
                         kvs.beginTransaction(opt).await();
                     });
                     assertEquals(KvsServiceCode.NOT_IMPLEMENTED, ex.getDiagnosticCode());
-                    System.err.println(getLineNumber() + "\t" + ex.getMessage());
+                    System.err.println(Utils.getLineNumber() + "\t" + ex.getMessage());
                 }
             }
         }
@@ -58,14 +58,14 @@ class BeginTest extends TestBase {
 
     @Test
     public void ltxWithArgs() throws Exception {
-        try (var session = getNewSession(); var kvs = KvsClient.attach(session)) {
+        try (var session = Utils.getNewSession(); var kvs = KvsClient.attach(session)) {
             {
                 var opt = TransactionOption.forLongTransaction().withLabel("abc").build();
                 KvsServiceException ex = assertThrows(KvsServiceException.class, () -> {
                     kvs.beginTransaction(opt).await();
                 });
                 assertEquals(KvsServiceCode.NOT_IMPLEMENTED, ex.getDiagnosticCode());
-                System.err.println(getLineNumber() + "\t" + ex.getMessage());
+                System.err.println(Utils.getLineNumber() + "\t" + ex.getMessage());
             }
             {
                 for (var p : Priority.values()) {
@@ -77,7 +77,7 @@ class BeginTest extends TestBase {
                         kvs.beginTransaction(opt).await();
                     });
                     assertEquals(KvsServiceCode.NOT_IMPLEMENTED, ex.getDiagnosticCode());
-                    System.err.println(getLineNumber() + "\t" + ex.getMessage());
+                    System.err.println(Utils.getLineNumber() + "\t" + ex.getMessage());
                 }
             }
             {
@@ -86,7 +86,7 @@ class BeginTest extends TestBase {
                     kvs.beginTransaction(opt).await();
                 });
                 assertEquals(KvsServiceCode.NOT_IMPLEMENTED, ex.getDiagnosticCode());
-                System.err.println(getLineNumber() + "\t" + ex.getMessage());
+                System.err.println(Utils.getLineNumber() + "\t" + ex.getMessage());
             }
             {
                 var opt = TransactionOption.forLongTransaction().addWritePreserve("table1").build();
@@ -94,7 +94,7 @@ class BeginTest extends TestBase {
                     kvs.beginTransaction(opt).await();
                 });
                 assertEquals(KvsServiceCode.NOT_IMPLEMENTED, ex.getDiagnosticCode());
-                System.err.println(getLineNumber() + "\t" + ex.getMessage());
+                System.err.println(Utils.getLineNumber() + "\t" + ex.getMessage());
             }
             {
                 var opt = TransactionOption.forLongTransaction().addInclusiveReadArea("table1").build();
@@ -102,7 +102,7 @@ class BeginTest extends TestBase {
                     kvs.beginTransaction(opt).await();
                 });
                 assertEquals(KvsServiceCode.NOT_IMPLEMENTED, ex.getDiagnosticCode());
-                System.err.println(getLineNumber() + "\t" + ex.getMessage());
+                System.err.println(Utils.getLineNumber() + "\t" + ex.getMessage());
             }
             {
                 var opt = TransactionOption.forLongTransaction().addExclusiveReadArea("table1").build();
@@ -110,27 +110,27 @@ class BeginTest extends TestBase {
                     kvs.beginTransaction(opt).await();
                 });
                 assertEquals(KvsServiceCode.NOT_IMPLEMENTED, ex.getDiagnosticCode());
-                System.err.println(getLineNumber() + "\t" + ex.getMessage());
+                System.err.println(Utils.getLineNumber() + "\t" + ex.getMessage());
             }
         }
     }
 
     @Test
     public void otherTypes() throws Exception {
-        try (var session = getNewSession(); var kvs = KvsClient.attach(session)) {
+        try (var session = Utils.getNewSession(); var kvs = KvsClient.attach(session)) {
             {
                 KvsServiceException ex = assertThrows(KvsServiceException.class, () -> {
                     kvs.beginTransaction(TransactionOption.forLongTransaction().build()).await();
                 });
                 assertEquals(KvsServiceCode.NOT_IMPLEMENTED, ex.getDiagnosticCode());
-                System.err.println(getLineNumber() + "\t" + ex.getMessage());
+                System.err.println(Utils.getLineNumber() + "\t" + ex.getMessage());
             }
             {
                 KvsServiceException ex = assertThrows(KvsServiceException.class, () -> {
                     kvs.beginTransaction(TransactionOption.forReadOnlyTransaction().build()).await();
                 });
                 assertEquals(KvsServiceCode.NOT_IMPLEMENTED, ex.getDiagnosticCode());
-                System.err.println(getLineNumber() + "\t" + ex.getMessage());
+                System.err.println(Utils.getLineNumber() + "\t" + ex.getMessage());
             }
         }
     }

--- a/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/basic/CommitTest.java
+++ b/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/basic/CommitTest.java
@@ -3,6 +3,7 @@ package com.tsurugidb.tsubakuro.kvs.basic;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import com.tsurugidb.tsubakuro.kvs.CommitType;
@@ -11,22 +12,23 @@ import com.tsurugidb.tsubakuro.kvs.KvsServiceCode;
 import com.tsurugidb.tsubakuro.kvs.KvsServiceException;
 import com.tsurugidb.tsubakuro.kvs.PutType;
 import com.tsurugidb.tsubakuro.kvs.RecordBuffer;
-import com.tsurugidb.tsubakuro.kvs.util.TestBase;
+import com.tsurugidb.tsubakuro.kvs.util.Utils;
 
-class CommitTest extends TestBase {
+class CommitTest {
 
     private static final String TABLE_NAME = "table" + CommitTest.class.getSimpleName();
     private static final String KEY_NAME = "k1";
     private static final String VALUE_NAME = "v1";
 
-    CommitTest() throws Exception {
+    @BeforeAll
+    static void setup() throws Exception {
         String schema = String.format("%s BIGINT PRIMARY KEY, %s BIGINT", KEY_NAME, VALUE_NAME);
-        createTable(TABLE_NAME, schema);
+        Utils.createTable(TABLE_NAME, schema);
     }
 
     @Test
     public void unspecified() throws Exception {
-        try (var session = getNewSession(); var kvs = KvsClient.attach(session)) {
+        try (var session = Utils.getNewSession(); var kvs = KvsClient.attach(session)) {
             try (var tx = kvs.beginTransaction().await()) {
                 RecordBuffer buffer = new RecordBuffer();
                 buffer.add(KEY_NAME, 1L);
@@ -39,7 +41,7 @@ class CommitTest extends TestBase {
 
     @Test
     public void multiCommit() throws Exception {
-        try (var session = getNewSession(); var kvs = KvsClient.attach(session)) {
+        try (var session = Utils.getNewSession(); var kvs = KvsClient.attach(session)) {
             try (var tx = kvs.beginTransaction().await()) {
                 RecordBuffer buffer = new RecordBuffer();
                 buffer.add(KEY_NAME, 1L);
@@ -57,7 +59,7 @@ class CommitTest extends TestBase {
 
     @Test
     public void opsAfterCommit() throws Exception {
-        try (var session = getNewSession(); var kvs = KvsClient.attach(session)) {
+        try (var session = Utils.getNewSession(); var kvs = KvsClient.attach(session)) {
             try (var tx = kvs.beginTransaction().await()) {
                 RecordBuffer buffer = new RecordBuffer();
                 buffer.add(KEY_NAME, 1L);
@@ -93,7 +95,7 @@ class CommitTest extends TestBase {
 
     @Test
     public void commitTypes() throws Exception {
-        try (var session = getNewSession(); var kvs = KvsClient.attach(session)) {
+        try (var session = Utils.getNewSession(); var kvs = KvsClient.attach(session)) {
             for (var cmtType : CommitType.values()) {
                 if (cmtType == CommitType.UNSPECIFIED) {
                     continue;
@@ -107,7 +109,7 @@ class CommitTest extends TestBase {
                         kvs.commit(tx, cmtType).await();
                     });
                     assertEquals(KvsServiceCode.NOT_IMPLEMENTED, ex.getDiagnosticCode());
-                    System.err.println(getLineNumber() + "\t" + ex.getMessage());
+                    System.err.println(Utils.getLineNumber() + "\t" + ex.getMessage());
                     // rollback and dispose will be called at tx.close()
                 }
             }

--- a/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/basic/DataTypesTest.java
+++ b/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/basic/DataTypesTest.java
@@ -19,9 +19,9 @@ import com.tsurugidb.tsubakuro.kvs.KvsServiceException;
 import com.tsurugidb.tsubakuro.kvs.Record;
 import com.tsurugidb.tsubakuro.kvs.RecordBuffer;
 import com.tsurugidb.tsubakuro.kvs.Values;
-import com.tsurugidb.tsubakuro.kvs.util.TestBase;
+import com.tsurugidb.tsubakuro.kvs.util.Utils;
 
-class DataTypesTest extends TestBase {
+class DataTypesTest {
 
     private static final String TABLE_NAME = "table" + DataTypesTest.class.getSimpleName();
     private static final String KEY_NAME = "k1";
@@ -30,7 +30,7 @@ class DataTypesTest extends TestBase {
     private static final int DECIMAL_SCALE = 2;
 
     private static BigDecimal toBigDecimal(KvsData.Value v) {
-        return toBigDecimal(v, DECIMAL_SCALE);
+        return Utils.toBigDecimal(v, DECIMAL_SCALE);
     }
 
     private static void checkValue(KvsData.Value expected, KvsData.Value value) throws Exception {
@@ -58,7 +58,7 @@ class DataTypesTest extends TestBase {
 
     private static void checkPutGet(KvsData.Value key1, KvsData.Value value1) throws Exception {
         RecordBuffer buffer = new RecordBuffer();
-        try (var session = getNewSession(); var kvs = KvsClient.attach(session)) {
+        try (var session = Utils.getNewSession(); var kvs = KvsClient.attach(session)) {
             try (var tx = kvs.beginTransaction().await()) {
                 buffer.add(KEY_NAME, key1);
                 buffer.add(VALUE_NAME, value1);
@@ -79,7 +79,7 @@ class DataTypesTest extends TestBase {
 
     private static void checkPutNG(KvsData.Value key1, KvsData.Value value1, KvsServiceCode code) throws Exception {
         RecordBuffer buffer = new RecordBuffer();
-        try (var session = getNewSession(); var kvs = KvsClient.attach(session)) {
+        try (var session = Utils.getNewSession(); var kvs = KvsClient.attach(session)) {
             try (var tx = kvs.beginTransaction().await()) {
                 buffer.add(KEY_NAME, key1);
                 buffer.add(VALUE_NAME, value1);
@@ -96,9 +96,9 @@ class DataTypesTest extends TestBase {
         return String.format("%s %s PRIMARY KEY, %s %s", KEY_NAME, typeName, VALUE_NAME, typeName);
     }
 
-    private void checkDataType(String typeName, KvsData.Value key1, KvsData.Value value1) throws Exception {
+    private static void checkDataType(String typeName, KvsData.Value key1, KvsData.Value value1) throws Exception {
         // see jogasaki/docs/value_limit.md
-        createTable(TABLE_NAME, schema(typeName));
+        Utils.createTable(TABLE_NAME, schema(typeName));
         checkPutGet(key1, value1);
     }
 
@@ -142,7 +142,7 @@ class DataTypesTest extends TestBase {
     public void char10Test() throws Exception {
         final String key1 = "1234567890"; // OK
         final String value1 = "abcdefghij"; // OK
-        createTable(TABLE_NAME, schema("char(10)"));
+        Utils.createTable(TABLE_NAME, schema("char(10)"));
         checkPutGet(Values.of(key1), Values.of(value1));
         //
         checkPutGet(Values.of(""), Values.of(""));
@@ -161,7 +161,7 @@ class DataTypesTest extends TestBase {
     public void varchar10Test() throws Exception {
         final String key1 = "1234567890"; // OK
         final String value1 = "abcdefghij"; // OK
-        createTable(TABLE_NAME, schema("varchar(10)"));
+        Utils.createTable(TABLE_NAME, schema("varchar(10)"));
         checkPutGet(Values.of(key1), Values.of(value1));
         //
         checkPutGet(Values.of(""), Values.of(""));
@@ -194,7 +194,7 @@ class DataTypesTest extends TestBase {
     public void decimalScaleTest() throws Exception {
         final BigDecimal key1 = new BigDecimal("12.34");
         final BigDecimal value1 = new BigDecimal("56.78");
-        createTable(TABLE_NAME, schema("decimal(4," + DECIMAL_SCALE + ")"));
+        Utils.createTable(TABLE_NAME, schema("decimal(4," + DECIMAL_SCALE + ")"));
         checkPutGet(Values.of(key1), Values.of(value1));
         // OK: too short integer part
         checkPutGet(Values.of(new BigDecimal("1.45")), Values.of(new BigDecimal("5.67")));

--- a/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/basic/GetTest.java
+++ b/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/basic/GetTest.java
@@ -3,30 +3,32 @@ package com.tsurugidb.tsubakuro.kvs.basic;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import com.tsurugidb.tsubakuro.kvs.KvsClient;
 import com.tsurugidb.tsubakuro.kvs.KvsServiceCode;
 import com.tsurugidb.tsubakuro.kvs.KvsServiceException;
 import com.tsurugidb.tsubakuro.kvs.RecordBuffer;
-import com.tsurugidb.tsubakuro.kvs.util.TestBase;
+import com.tsurugidb.tsubakuro.kvs.util.Utils;
 
-class GetTest extends TestBase {
+class GetTest {
 
     private static final String TABLE_NAME = "table" + GetTest.class.getSimpleName();
     private static final String KEY_NAME = "k1";
     private static final String VALUE_NAME = "v1";
 
-    GetTest() throws Exception {
+    @BeforeAll
+    static void setup() throws Exception {
         String schema = String.format("%s BIGINT PRIMARY KEY, %s BIGINT", KEY_NAME, VALUE_NAME);
-        createTable(TABLE_NAME, schema);
+        Utils.createTable(TABLE_NAME, schema);
     }
 
     @Test
     public void invalidRequests() throws Exception {
         final long key1 = 1L;
         RecordBuffer key = new RecordBuffer();
-        try (var session = getNewSession(); var kvs = KvsClient.attach(session)) {
+        try (var session = Utils.getNewSession(); var kvs = KvsClient.attach(session)) {
             // COLUMN_TYPE_MISMATCH
             try (var tx = kvs.beginTransaction().await()) {
                 key.clear();

--- a/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/basic/NotNullDataTypesTest.java
+++ b/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/basic/NotNullDataTypesTest.java
@@ -16,9 +16,9 @@ import com.tsurugidb.tsubakuro.kvs.KvsServiceCode;
 import com.tsurugidb.tsubakuro.kvs.KvsServiceException;
 import com.tsurugidb.tsubakuro.kvs.RecordBuffer;
 import com.tsurugidb.tsubakuro.kvs.Values;
-import com.tsurugidb.tsubakuro.kvs.util.TestBase;
+import com.tsurugidb.tsubakuro.kvs.util.Utils;
 
-class NotNullDataTypesTest extends TestBase {
+class NotNullDataTypesTest {
 
     private static final String TABLE_NAME = "table" + NotNullDataTypesTest.class.getSimpleName();
     private static final String KEY_NAME = "k1";
@@ -26,7 +26,7 @@ class NotNullDataTypesTest extends TestBase {
 
     private static void checkPutGet(KvsData.Value key1, KvsData.Value value1) throws Exception {
         RecordBuffer buffer = new RecordBuffer();
-        try (var session = getNewSession(); var kvs = KvsClient.attach(session)) {
+        try (var session = Utils.getNewSession(); var kvs = KvsClient.attach(session)) {
             // key: null, value: non-null
             try (var tx = kvs.beginTransaction().await()) {
                 buffer.addNull(KEY_NAME);
@@ -65,9 +65,9 @@ class NotNullDataTypesTest extends TestBase {
         return String.format("%s %s PRIMARY KEY, %s %s NOT NULL", KEY_NAME, typeName, VALUE_NAME, typeName);
     }
 
-    private void checkDataType(String typeName, KvsData.Value key1, KvsData.Value value1) throws Exception {
+    private static void checkDataType(String typeName, KvsData.Value key1, KvsData.Value value1) throws Exception {
         // see jogasaki/docs/value_limit.md
-        createTable(TABLE_NAME, schema(typeName));
+        Utils.createTable(TABLE_NAME, schema(typeName));
         checkPutGet(key1, value1);
     }
 
@@ -124,7 +124,7 @@ class NotNullDataTypesTest extends TestBase {
     public void decimalScaleTest() throws Exception {
         final BigDecimal key1 = new BigDecimal("12.34");
         final BigDecimal value1 = new BigDecimal("56.78");
-        createTable(TABLE_NAME, schema("decimal(4,2)"));
+        Utils.createTable(TABLE_NAME, schema("decimal(4,2)"));
         checkPutGet(Values.of(key1), Values.of(value1));
     }
 

--- a/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/basic/NullDataTypesTest.java
+++ b/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/basic/NullDataTypesTest.java
@@ -17,9 +17,9 @@ import com.tsurugidb.tsubakuro.kvs.KvsServiceException;
 import com.tsurugidb.tsubakuro.kvs.Record;
 import com.tsurugidb.tsubakuro.kvs.RecordBuffer;
 import com.tsurugidb.tsubakuro.kvs.Values;
-import com.tsurugidb.tsubakuro.kvs.util.TestBase;
+import com.tsurugidb.tsubakuro.kvs.util.Utils;
 
-class NullDataTypesTest extends TestBase {
+class NullDataTypesTest {
 
     private static final String TABLE_NAME = "table" + NullDataTypesTest.class.getSimpleName();
     private static final String KEY_NAME = "k1";
@@ -36,7 +36,7 @@ class NullDataTypesTest extends TestBase {
 
     private static void checkPutGet(KvsData.Value key1, KvsData.Value value1) throws Exception {
         RecordBuffer buffer = new RecordBuffer();
-        try (var session = getNewSession(); var kvs = KvsClient.attach(session)) {
+        try (var session = Utils.getNewSession(); var kvs = KvsClient.attach(session)) {
             // key: null, value: non-null
             try (var tx = kvs.beginTransaction().await()) {
                 buffer.addNull(KEY_NAME);
@@ -84,9 +84,9 @@ class NullDataTypesTest extends TestBase {
         return String.format("%s %s PRIMARY KEY, %s %s", KEY_NAME, typeName, VALUE_NAME, typeName);
     }
 
-    private void checkDataType(String typeName, KvsData.Value key1, KvsData.Value value1) throws Exception {
+    private static void checkDataType(String typeName, KvsData.Value key1, KvsData.Value value1) throws Exception {
         // see jogasaki/docs/value_limit.md
-        createTable(TABLE_NAME, schema(typeName));
+        Utils.createTable(TABLE_NAME, schema(typeName));
         checkPutGet(key1, value1);
     }
 
@@ -143,7 +143,7 @@ class NullDataTypesTest extends TestBase {
     public void decimalScaleTest() throws Exception {
         final BigDecimal key1 = new BigDecimal("12.34");
         final BigDecimal value1 = new BigDecimal("56.78");
-        createTable(TABLE_NAME, schema("decimal(4,2)"));
+        Utils.createTable(TABLE_NAME, schema("decimal(4,2)"));
         checkPutGet(Values.of(key1), Values.of(value1));
     }
 

--- a/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/basic/PutMultiValuesTest.java
+++ b/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/basic/PutMultiValuesTest.java
@@ -3,6 +3,7 @@ package com.tsurugidb.tsubakuro.kvs.basic;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import com.tsurugidb.tsubakuro.kvs.KvsClient;
@@ -10,19 +11,20 @@ import com.tsurugidb.tsubakuro.kvs.KvsServiceCode;
 import com.tsurugidb.tsubakuro.kvs.KvsServiceException;
 import com.tsurugidb.tsubakuro.kvs.Record;
 import com.tsurugidb.tsubakuro.kvs.RecordBuffer;
-import com.tsurugidb.tsubakuro.kvs.util.TestBase;
+import com.tsurugidb.tsubakuro.kvs.util.Utils;
 
-class PutMultiValuesTest extends TestBase {
+class PutMultiValuesTest {
 
     private static final String TABLE_NAME = "table" + PutMultiValuesTest.class.getSimpleName();
     private static final String KEY_NAME = "k1";
     private static final String VALUE1_NAME = "v1";
     private static final String VALUE2_NAME = "v2";
 
-    PutMultiValuesTest() throws Exception {
+    @BeforeAll
+    static void setup() throws Exception {
         String schema = String.format("%s BIGINT PRIMARY KEY, %s BIGINT, %s BIGINT", KEY_NAME, VALUE1_NAME,
                 VALUE2_NAME);
-        createTable(TABLE_NAME, schema);
+        Utils.createTable(TABLE_NAME, schema);
     }
 
     private static void checkRecord(Record record, long key1, long value1, long value2) throws Exception {
@@ -45,7 +47,7 @@ class PutMultiValuesTest extends TestBase {
         final long key1 = 1L;
         final long value1 = 100L;
         final long value2 = 101L;
-        try (var session = getNewSession(); var kvs = KvsClient.attach(session)) {
+        try (var session = Utils.getNewSession(); var kvs = KvsClient.attach(session)) {
             try (var tx = kvs.beginTransaction().await()) {
                 RecordBuffer buffer = new RecordBuffer();
                 buffer.add(KEY_NAME, key1);
@@ -82,7 +84,7 @@ class PutMultiValuesTest extends TestBase {
         final long key1 = 1L;
         final long value1 = 100L;
         final long value2 = 101L;
-        try (var session = getNewSession(); var kvs = KvsClient.attach(session)) {
+        try (var session = Utils.getNewSession(); var kvs = KvsClient.attach(session)) {
             try (var tx = kvs.beginTransaction().await()) {
                 RecordBuffer buffer = new RecordBuffer();
                 buffer.add(VALUE1_NAME, value2);
@@ -141,7 +143,7 @@ class PutMultiValuesTest extends TestBase {
         final long value1 = 100L;
         final long value2 = 101L;
         RecordBuffer buffer = new RecordBuffer();
-        try (var session = getNewSession(); var kvs = KvsClient.attach(session)) {
+        try (var session = Utils.getNewSession(); var kvs = KvsClient.attach(session)) {
             try (var tx = kvs.beginTransaction().await()) {
                 buffer.add(KEY_NAME, key1);
                 buffer.add(VALUE1_NAME, value1);

--- a/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/basic/PutTest.java
+++ b/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/basic/PutTest.java
@@ -3,6 +3,7 @@ package com.tsurugidb.tsubakuro.kvs.basic;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import com.tsurugidb.tsubakuro.kvs.KvsClient;
@@ -10,17 +11,18 @@ import com.tsurugidb.tsubakuro.kvs.KvsServiceCode;
 import com.tsurugidb.tsubakuro.kvs.KvsServiceException;
 import com.tsurugidb.tsubakuro.kvs.PutType;
 import com.tsurugidb.tsubakuro.kvs.RecordBuffer;
-import com.tsurugidb.tsubakuro.kvs.util.TestBase;
+import com.tsurugidb.tsubakuro.kvs.util.Utils;
 
-class PutTest extends TestBase {
+class PutTest {
 
     private static final String TABLE_NAME = "table" + PutTest.class.getSimpleName();
     private static final String KEY_NAME = "k1";
     private static final String VALUE_NAME = "v1";
 
-    PutTest() throws Exception {
+    @BeforeAll
+    static void setup() throws Exception {
         String schema = String.format("%s BIGINT PRIMARY KEY, %s BIGINT", KEY_NAME, VALUE_NAME);
-        createTable(TABLE_NAME, schema);
+        Utils.createTable(TABLE_NAME, schema);
     }
 
     @Test
@@ -28,7 +30,7 @@ class PutTest extends TestBase {
         final long key1 = 1L;
         final long value1 = 100L;
         RecordBuffer buffer = new RecordBuffer();
-        try (var session = getNewSession(); var kvs = KvsClient.attach(session)) {
+        try (var session = Utils.getNewSession(); var kvs = KvsClient.attach(session)) {
             // COLUMN_TYPE_MISMATCH
             try (var tx = kvs.beginTransaction().await()) {
                 buffer.clear();

--- a/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/basic/RemoveTest.java
+++ b/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/basic/RemoveTest.java
@@ -3,30 +3,32 @@ package com.tsurugidb.tsubakuro.kvs.basic;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import com.tsurugidb.tsubakuro.kvs.KvsClient;
 import com.tsurugidb.tsubakuro.kvs.KvsServiceCode;
 import com.tsurugidb.tsubakuro.kvs.KvsServiceException;
 import com.tsurugidb.tsubakuro.kvs.RecordBuffer;
-import com.tsurugidb.tsubakuro.kvs.util.TestBase;
+import com.tsurugidb.tsubakuro.kvs.util.Utils;
 
-class RemoveTest extends TestBase {
+class RemoveTest {
 
     private static final String TABLE_NAME = "table" + RemoveTest.class.getSimpleName();
     private static final String KEY_NAME = "k1";
     private static final String VALUE_NAME = "v1";
 
-    RemoveTest() throws Exception {
+    @BeforeAll
+    static void setup() throws Exception {
         String schema = String.format("%s BIGINT PRIMARY KEY, %s BIGINT", KEY_NAME, VALUE_NAME);
-        createTable(TABLE_NAME, schema);
+        Utils.createTable(TABLE_NAME, schema);
     }
 
     @Test
     public void invalidRequests() throws Exception {
         final long key1 = 1L;
         RecordBuffer key = new RecordBuffer();
-        try (var session = getNewSession(); var kvs = KvsClient.attach(session)) {
+        try (var session = Utils.getNewSession(); var kvs = KvsClient.attach(session)) {
             // COLUMN_TYPE_MISMATCH
             try (var tx = kvs.beginTransaction().await()) {
                 key.clear();

--- a/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/basic/RollbackTest.java
+++ b/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/basic/RollbackTest.java
@@ -3,6 +3,7 @@ package com.tsurugidb.tsubakuro.kvs.basic;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import com.tsurugidb.tsubakuro.kvs.KvsClient;
@@ -10,17 +11,18 @@ import com.tsurugidb.tsubakuro.kvs.KvsServiceCode;
 import com.tsurugidb.tsubakuro.kvs.KvsServiceException;
 import com.tsurugidb.tsubakuro.kvs.PutType;
 import com.tsurugidb.tsubakuro.kvs.RecordBuffer;
-import com.tsurugidb.tsubakuro.kvs.util.TestBase;
+import com.tsurugidb.tsubakuro.kvs.util.Utils;
 
-class RollbackTest extends TestBase {
+class RollbackTest {
 
     private static final String TABLE_NAME = "table" + RollbackTest.class.getSimpleName();
     private static final String KEY_NAME = "k1";
     private static final String VALUE_NAME = "v1";
 
-    RollbackTest() throws Exception {
+    @BeforeAll
+    static void setup() throws Exception {
         String schema = String.format("%s BIGINT PRIMARY KEY, %s BIGINT", KEY_NAME, VALUE_NAME);
-        createTable(TABLE_NAME, schema);
+        Utils.createTable(TABLE_NAME, schema);
     }
 
     @Test
@@ -29,7 +31,7 @@ class RollbackTest extends TestBase {
         final long value1 = 100L;
         final long value2 = 200L;
         RecordBuffer buffer = new RecordBuffer();
-        try (var session = getNewSession(); var kvs = KvsClient.attach(session)) {
+        try (var session = Utils.getNewSession(); var kvs = KvsClient.attach(session)) {
             // initial insert
             try (var tx = kvs.beginTransaction().await()) {
                 buffer.add(KEY_NAME, key1);
@@ -90,7 +92,7 @@ class RollbackTest extends TestBase {
 
     @Test
     public void multiRollback() throws Exception {
-        try (var session = getNewSession(); var kvs = KvsClient.attach(session)) {
+        try (var session = Utils.getNewSession(); var kvs = KvsClient.attach(session)) {
             try (var tx = kvs.beginTransaction().await()) {
                 RecordBuffer buffer = new RecordBuffer();
                 buffer.add(KEY_NAME, 1L);
@@ -108,7 +110,7 @@ class RollbackTest extends TestBase {
 
     @Test
     public void opsAfterRollback() throws Exception {
-        try (var session = getNewSession(); var kvs = KvsClient.attach(session)) {
+        try (var session = Utils.getNewSession(); var kvs = KvsClient.attach(session)) {
             try (var tx = kvs.beginTransaction().await()) {
                 RecordBuffer buffer = new RecordBuffer();
                 buffer.add(KEY_NAME, 1L);

--- a/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/basic/ScanTest.java
+++ b/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/basic/ScanTest.java
@@ -8,9 +8,9 @@ import com.tsurugidb.tsubakuro.kvs.KvsClient;
 import com.tsurugidb.tsubakuro.kvs.RecordBuffer;
 import com.tsurugidb.tsubakuro.kvs.ScanBound;
 import com.tsurugidb.tsubakuro.kvs.ScanType;
-import com.tsurugidb.tsubakuro.kvs.util.TestBase;
+import com.tsurugidb.tsubakuro.kvs.util.Utils;
 
-class ScanTest extends TestBase {
+class ScanTest {
 
     private static final String TABLE_NAME = "table" + ScanTest.class.getSimpleName();
 
@@ -21,7 +21,7 @@ class ScanTest extends TestBase {
         RecordBuffer upperKey = new RecordBuffer();
         ScanBound upperBound = ScanBound.INCLUSIVE;
         ScanType behavior = ScanType.FORWARD;
-        try (var session = getNewSession(); var kvs = KvsClient.attach(session)) {
+        try (var session = Utils.getNewSession(); var kvs = KvsClient.attach(session)) {
             try (var tx = kvs.beginTransaction().await()) {
                 assertThrows(UnsupportedOperationException.class,
                         () -> kvs.scan(tx, TABLE_NAME, lowerKey, lowerBound, upperKey, upperBound, behavior).await());

--- a/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/basic/SecondaryIndexTableTest.java
+++ b/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/basic/SecondaryIndexTableTest.java
@@ -3,32 +3,34 @@ package com.tsurugidb.tsubakuro.kvs.basic;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import com.tsurugidb.tsubakuro.kvs.KvsClient;
 import com.tsurugidb.tsubakuro.kvs.KvsServiceCode;
 import com.tsurugidb.tsubakuro.kvs.KvsServiceException;
 import com.tsurugidb.tsubakuro.kvs.RecordBuffer;
-import com.tsurugidb.tsubakuro.kvs.util.TestBase;
+import com.tsurugidb.tsubakuro.kvs.util.Utils;
 
-class SecondaryIndexTableTest extends TestBase {
+class SecondaryIndexTableTest {
 
     private static final String TABLE_NAME = "table" + SecondaryIndexTableTest.class.getSimpleName();
     private static final String KEY_NAME = "k1";
     private static final String VALUE_NAME = "v1";
 
-    SecondaryIndexTableTest() throws Exception {
+    @BeforeAll
+    static void setup() throws Exception {
         String schema = String.format("%s BIGINT PRIMARY KEY, %s BIGINT", KEY_NAME, VALUE_NAME);
-        createTable(TABLE_NAME, schema);
+        Utils.createTable(TABLE_NAME, schema);
         String sql = String.format("CREATE INDEX %s on %s(%s)", "index" + VALUE_NAME, TABLE_NAME, VALUE_NAME);
-        executeStatement(sql);
+        Utils.executeStatement(sql);
     }
 
     @Test
     public void basicPutGetRemove() throws Exception {
         final long key1 = 1L;
         final long value1 = 100L;
-        try (var session = getNewSession(); var kvs = KvsClient.attach(session)) {
+        try (var session = Utils.getNewSession(); var kvs = KvsClient.attach(session)) {
             try (var tx = kvs.beginTransaction().await()) {
                 RecordBuffer buffer = new RecordBuffer();
                 buffer.add(KEY_NAME, key1);
@@ -37,7 +39,7 @@ class SecondaryIndexTableTest extends TestBase {
                     kvs.put(tx, TABLE_NAME, buffer).await();
                 });
                 assertEquals(KvsServiceCode.NOT_IMPLEMENTED, ex.getDiagnosticCode());
-                System.err.println(getLineNumber() + "\t" + ex.getMessage());
+                System.err.println(Utils.getLineNumber() + "\t" + ex.getMessage());
                 kvs.rollback(tx).await();
             }
             RecordBuffer keyBuffer = new RecordBuffer();
@@ -54,7 +56,7 @@ class SecondaryIndexTableTest extends TestBase {
                     kvs.remove(tx, TABLE_NAME, keyBuffer).await();
                 });
                 assertEquals(KvsServiceCode.NOT_IMPLEMENTED, ex.getDiagnosticCode());
-                System.err.println(getLineNumber() + "\t" + ex.getMessage());
+                System.err.println(Utils.getLineNumber() + "\t" + ex.getMessage());
                 kvs.rollback(tx).await();
             }
         }

--- a/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/basic/SessionClientTest.java
+++ b/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/basic/SessionClientTest.java
@@ -2,28 +2,30 @@ package com.tsurugidb.tsubakuro.kvs.basic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import com.tsurugidb.tsubakuro.kvs.KvsClient;
 import com.tsurugidb.tsubakuro.kvs.RecordBuffer;
-import com.tsurugidb.tsubakuro.kvs.util.TestBase;
+import com.tsurugidb.tsubakuro.kvs.util.Utils;
 
-class SessionClientTest extends TestBase {
+class SessionClientTest {
 
     private static final String TABLE_NAME = "table" + SessionClientTest.class.getSimpleName();
     private static final String KEY_NAME = "k1";
     private static final String VALUE_NAME = "v1";
 
-    SessionClientTest() throws Exception {
+    @BeforeAll
+    static void setup() throws Exception {
         String schema = String.format("%s BIGINT PRIMARY KEY, %s BIGINT", KEY_NAME, VALUE_NAME);
-        createTable(TABLE_NAME, schema);
+        Utils.createTable(TABLE_NAME, schema);
     }
 
     @Test
     public void reuseSession() throws Exception {
         final long key1 = 1L;
         final long value1 = 100L;
-        try (var session = getNewSession()) {
+        try (var session = Utils.getNewSession()) {
             try (var kvs = KvsClient.attach(session)) {
                 try (var tx = kvs.beginTransaction().await()) {
                     RecordBuffer buffer = new RecordBuffer();
@@ -57,7 +59,7 @@ class SessionClientTest extends TestBase {
 
     @Test
     public void recloses() throws Exception {
-        try (var session = getNewSession()) {
+        try (var session = Utils.getNewSession()) {
             try (var kvs = KvsClient.attach(session)) {
                 try (var tx = kvs.beginTransaction().await()) {
                     tx.close();
@@ -73,7 +75,7 @@ class SessionClientTest extends TestBase {
         final long key1 = 1L;
         final long value1 = 100L;
         final long value2 = 101L;
-        try (var session = getNewSession()) {
+        try (var session = Utils.getNewSession()) {
             try (var kvs = KvsClient.attach(session)) {
                 try (var tx = kvs.beginTransaction().await()) {
                     RecordBuffer buffer = new RecordBuffer();

--- a/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/compatibility/BasicTest.java
+++ b/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/compatibility/BasicTest.java
@@ -8,18 +8,18 @@ import org.junit.jupiter.api.Test;
 
 import com.tsurugidb.tsubakuro.kvs.KvsClient;
 import com.tsurugidb.tsubakuro.kvs.RecordBuffer;
-import com.tsurugidb.tsubakuro.kvs.util.TestBase;
+import com.tsurugidb.tsubakuro.kvs.util.Utils;
 import com.tsurugidb.tsubakuro.sql.SqlClient;
 
-class BasicTest extends TestBase {
+class BasicTest {
 
     private static final String TABLE_NAME = "table" + BasicTest.class.getSimpleName();
     private static final String KEY_NAME = "k1";
     private static final String VALUE_NAME = "v1";
 
-    private void createTable() throws Exception {
+    private static void createTable() throws Exception {
         String schema = String.format("%s BIGINT PRIMARY KEY, %s BIGINT", KEY_NAME, VALUE_NAME);
-        createTable(TABLE_NAME, schema);
+        Utils.createTable(TABLE_NAME, schema);
     }
 
     private static void checkSQLrecord(SqlClient sql, long key, long value) throws Exception {
@@ -135,7 +135,7 @@ class BasicTest extends TestBase {
         final long value1 = 100L;
         final long key2 = 2L;
         final long value2 = 200L;
-        try (var session = getNewSession(); var sql = SqlClient.attach(session); var kvs = KvsClient.attach(session)) {
+        try (var session = Utils.getNewSession(); var sql = SqlClient.attach(session); var kvs = KvsClient.attach(session)) {
             // SQL INSERT
             try (var tx = sql.createTransaction().await()) {
                 var st = String.format("INSERT INTO %s (%s, %s) VALUES(%d, %d)", TABLE_NAME, KEY_NAME, VALUE_NAME, key1,
@@ -207,7 +207,7 @@ class BasicTest extends TestBase {
         final long value1 = 100L;
         final long key2 = 2L;
         final long value2 = 200L;
-        try (var session = getNewSession(); var sql = SqlClient.attach(session); var kvs = KvsClient.attach(session)) {
+        try (var session = Utils.getNewSession(); var sql = SqlClient.attach(session); var kvs = KvsClient.attach(session)) {
             // SQL INSERT (value is null)
             try (var tx = sql.createTransaction().await()) {
                 var st = String.format("INSERT INTO %s (%s) VALUES(%d)", TABLE_NAME, KEY_NAME, key1);

--- a/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/compatibility/CompatBase.java
+++ b/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/compatibility/CompatBase.java
@@ -13,11 +13,11 @@ import com.tsurugidb.tsubakuro.kvs.Record;
 import com.tsurugidb.tsubakuro.kvs.RecordBuffer;
 import com.tsurugidb.tsubakuro.kvs.Values;
 import com.tsurugidb.tsubakuro.kvs.impl.GetResultImpl;
-import com.tsurugidb.tsubakuro.kvs.util.TestBase;
+import com.tsurugidb.tsubakuro.kvs.util.Utils;
 import com.tsurugidb.tsubakuro.sql.ResultSet;
 import com.tsurugidb.tsubakuro.sql.SqlClient;
 
-class CompatBase extends TestBase {
+class CompatBase {
 
     final String tableName;
     final int decimalScale;
@@ -95,7 +95,7 @@ class CompatBase extends TestBase {
     }
 
     private BigDecimal toBigDecimal(KvsData.Value v) {
-        return toBigDecimal(v, decimalScale);
+        return Utils.toBigDecimal(v, decimalScale);
     }
 
     private void checkValue(KvsData.Value expected, KvsData.Value value) throws Exception {

--- a/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/compatibility/CompatDataTypesTest.java
+++ b/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/compatibility/CompatDataTypesTest.java
@@ -13,6 +13,7 @@ import com.tsurugidb.kvs.proto.KvsData;
 import com.tsurugidb.tsubakuro.kvs.KvsClient;
 import com.tsurugidb.tsubakuro.kvs.RecordBuffer;
 import com.tsurugidb.tsubakuro.kvs.Values;
+import com.tsurugidb.tsubakuro.kvs.util.Utils;
 import com.tsurugidb.tsubakuro.sql.SqlClient;
 
 class CompatDataTypesTest extends CompatBase {
@@ -25,7 +26,7 @@ class CompatDataTypesTest extends CompatBase {
     }
 
     private void checkNonNull(SqlValue key1, SqlValue value1, SqlValue key2, SqlValue value2) throws Exception {
-        try (var session = getNewSession(); var sql = SqlClient.attach(session); var kvs = KvsClient.attach(session)) {
+        try (var session = Utils.getNewSession(); var sql = SqlClient.attach(session); var kvs = KvsClient.attach(session)) {
             // SQL INSERT
             try (var tx = sql.createTransaction().await()) {
                 var st = String.format("INSERT INTO %s (%s, %s) VALUES(%s, %s)", TABLE_NAME, KEY_NAME, VALUE_NAME,
@@ -91,7 +92,7 @@ class CompatDataTypesTest extends CompatBase {
     }
 
     private void checkWithNull(SqlValue key1, SqlValue value1, SqlValue key2, SqlValue value2) throws Exception {
-        try (var session = getNewSession(); var sql = SqlClient.attach(session); var kvs = KvsClient.attach(session)) {
+        try (var session = Utils.getNewSession(); var sql = SqlClient.attach(session); var kvs = KvsClient.attach(session)) {
             // SQL INSERT (value is null)
             try (var tx = sql.createTransaction().await()) {
                 var st = String.format("INSERT INTO %s (%s) VALUES(%s)", TABLE_NAME, KEY_NAME, key1.str);
@@ -190,7 +191,7 @@ class CompatDataTypesTest extends CompatBase {
     private void checkDataType(String typeName, KvsData.Value key1, KvsData.Value value1, KvsData.Value key2,
             KvsData.Value value2) throws Exception {
         // see jogasaki/docs/value_limit.md
-        createTable(TABLE_NAME, schema(typeName));
+        Utils.createTable(TABLE_NAME, schema(typeName));
         check(typeName, key1, value1, key2, value2);
     }
 

--- a/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/compatibility/CompatMultiValuesTest.java
+++ b/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/compatibility/CompatMultiValuesTest.java
@@ -7,25 +7,26 @@ import org.junit.jupiter.api.Test;
 import com.tsurugidb.tsubakuro.kvs.KvsClient;
 import com.tsurugidb.tsubakuro.kvs.RecordBuffer;
 import com.tsurugidb.tsubakuro.kvs.Values;
+import com.tsurugidb.tsubakuro.kvs.util.Utils;
 import com.tsurugidb.tsubakuro.sql.SqlClient;
 
 class CompatMultiValuesTest extends CompatBase {
 
     private static final String TABLE_NAME = "table" + CompatMultiValuesTest.class.getSimpleName();
 
-    CompatMultiValuesTest() throws Exception {
+    CompatMultiValuesTest() {
         super(TABLE_NAME);
     }
 
     @Test
     public void basic() throws Exception {
         String typeName = "bigint";
-        createTable(TABLE_NAME, schemaV2(typeName));
+        Utils.createTable(TABLE_NAME, schemaV2(typeName));
         final SqlValue key1 = new SqlValue(typeName, Values.of(1L));
         final SqlValue key2 = new SqlValue(typeName, Values.of(2L));
         final SqlValue value1 = new SqlValue(typeName, Values.of(100L));
         final SqlValue value2 = new SqlValue(typeName, Values.of(200L));
-        try (var session = getNewSession(); var sql = SqlClient.attach(session); var kvs = KvsClient.attach(session)) {
+        try (var session = Utils.getNewSession(); var sql = SqlClient.attach(session); var kvs = KvsClient.attach(session)) {
             // SQL INSERT
             try (var tx = sql.createTransaction().await()) {
                 var st = String.format("INSERT INTO %s (%s, %s, %s) VALUES(%s, %s, %s)", TABLE_NAME, KEY_NAME,

--- a/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/util/Utils.java
+++ b/modules/kvs/src/inttest/java/com/tsurugidb/tsubakuro/kvs/util/Utils.java
@@ -13,7 +13,7 @@ import com.tsurugidb.tsubakuro.sql.SqlClient;
 /**
  * The base class for integration test class.
  */
-public class TestBase {
+public final class Utils {
 
     private static final String SYSPROP_KVSTEST_ENDPOINT = "tsurugi.kvstest.endpoint";
     private static final URI ENDPOINT;
@@ -22,6 +22,9 @@ public class TestBase {
         String uri = System.getProperty(SYSPROP_KVSTEST_ENDPOINT, "ipc:tsurugi");
         ENDPOINT = URI.create(uri);
         System.err.println("endpoint=" + ENDPOINT);
+    }
+
+    private Utils() {
     }
 
     /**
@@ -54,7 +57,7 @@ public class TestBase {
      * @throws Exception failed to drop the table
      * @note exception doesn't throw even if the table doesn't exists
      */
-    public void dropTable(String tableName) throws Exception {
+    public static void dropTable(String tableName) throws Exception {
         try (var session = getNewSession(); var client = SqlClient.attach(session)) {
             dropTable(client, tableName);
         }
@@ -66,7 +69,7 @@ public class TestBase {
      * @param schema the schema of the table
      * @throws Exception failed to create a new table
      */
-    public void createTable(String tableName, String schema) throws Exception {
+    public static void createTable(String tableName, String schema) throws Exception {
         try (var session = getNewSession(); var client = SqlClient.attach(session)) {
             dropTable(client, tableName);
             try (var tx = client.createTransaction().await()) {
@@ -83,7 +86,7 @@ public class TestBase {
      * @param sql SQL statement
      * @throws Exception failed to execute the SQL statement
      */
-    public void executeStatement(String sql) throws Exception {
+    public static void executeStatement(String sql) throws Exception {
         try (var session = getNewSession(); var client = SqlClient.attach(session)) {
             try (var tx = client.createTransaction().await()) {
                 tx.executeStatement(sql).await();


### PR DESCRIPTION
コンストラクタが例外をthrowするようになっていたため、finalizer attackの問題がありました。

これらのコンストラクタは、JUnitテストでテストクラスの初期化処理（テスト用テーブル作成）をしていました。
JUnitのお作法に従い、コンストラクタではなく、``@BeforeAll static void setup() throws Exception`` なメソッドに書き換えました。

テストクラスはTestBaseクラスを継承するのをやめ、Utils.createTable()などとstaticメソッドを呼び出すように変えました。

一時的に SpotBugsのチェックありとして、修正前は出たfinalizser attackの指摘が出なくなったことを確認しました。