### PR TITLE
build: remove dependency for boost::stacktrace_backtrace

### DIFF
--- a/tools/tpc-c-datagen/CMakeLists.txt
+++ b/tools/tpc-c-datagen/CMakeLists.txt
@@ -50,7 +50,7 @@ find_package(glog REQUIRED)
 find_package(gflags REQUIRED)
 find_package(Threads REQUIRED)
 find_package(Boost
-        COMPONENTS filesystem thread system container stacktrace_backtrace
+        COMPONENTS filesystem thread system container
         REQUIRED
         )
 include(GNUInstallDirs)


### PR DESCRIPTION
Fix problems related https://github.com/project-tsurugi/tsurugi-issues/issues/1065