### PR TITLE
build: introduce Gradle Toolchain Resolver Plugin

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,7 @@
+plugins {
+  id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
+}
+
 rootProject.name = 'tsubakuro-examples'
 
 include 'tpcc'


### PR DESCRIPTION
Introduce Toolchain Resolver Plugin for enabling Java toolchain auto-provisioning feature.